### PR TITLE
Separate text and image chat conversations

### DIFF
--- a/ai-image-editor/components/ChatInterface.tsx
+++ b/ai-image-editor/components/ChatInterface.tsx
@@ -20,6 +20,7 @@ interface Message {
   isUser: boolean;
   timestamp: any;
   isLoading?: boolean;
+  conversationType?: 'text' | 'image'; // Track what type of conversation this message belongs to
 }
 
 interface ChatInterfaceProps {
@@ -147,7 +148,12 @@ export default function ChatInterface({ conversationId }: ChatInterfaceProps) {
 
     const userMessage = input.trim();
     const images = [...uploadedImages];
-    const currentConvId = conversationId || `conv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    
+    // Create conversation type based on current tab and whether images are uploaded
+    const conversationType: 'text' | 'image' = activeTab === 'photo' || images.length > 0 ? 'image' : 'text';
+    
+    // Generate conversation ID with type prefix for better organization
+    const currentConvId = conversationId || `${conversationType}_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
     
     // Clear input immediately
     setInput('');
@@ -192,6 +198,7 @@ export default function ChatInterface({ conversationId }: ChatInterfaceProps) {
       await addDoc(collection(db, 'messages'), {
         userId: user.uid,
         conversationId: currentConvId,
+        conversationType: conversationType,
         text: userMessage,
         images: uploadedUrls,
         isUser: true,
@@ -251,6 +258,7 @@ export default function ChatInterface({ conversationId }: ChatInterfaceProps) {
       const aiMessageData: any = {
         userId: user.uid,
         conversationId: currentConvId,
+        conversationType: conversationType,
         isUser: false,
         timestamp: serverTimestamp(),
         modelUsed: result.modelUsed,


### PR DESCRIPTION
## Summary
- Added conversation type tracking to differentiate text chats from image chats
- Updated Message interface to include `conversationType` field
- Modified conversation ID generation to use type prefixes (`text_*` and `image_*`)
- Completely redesigned Sidebar to show separate sections for text and image chats
- Implemented visual distinction with blue theme for text chats and purple theme for image chats

## Technical Implementation Details
- **Message Interface**: Added optional `conversationType?: 'text' | 'image'` field
- **Conversation Creation**: Conversations are now categorized based on `activeTab` and presence of uploaded images
- **ID Prefixing**: Text conversations use `text_${timestamp}` format, image conversations use `image_${timestamp}`
- **Sidebar Redesign**: Two distinct sections with themed styling and appropriate icons
- **Backward Compatibility**: Existing conversations without `conversationType` are handled gracefully

## Benefits and Impact
- Clear separation between text-based AI conversations and image generation/editing sessions
- Improved user experience with organized conversation history
- Better visual distinction helps users quickly identify conversation types
- Maintains all existing functionality while adding new organizational features

## Test Cases Covered
- Creating new text conversations in chat mode
- Creating new image conversations in photo mode
- Mixed conversations (text with images) are properly categorized
- Existing conversations display correctly with fallback logic
- Sidebar filtering works correctly for both conversation types

🎫 Monday Ticket: Separate text and image chat conversations
🤖 Generated with [Claude Code](https://claude.ai/code)